### PR TITLE
added ternary logic to fix no fillings bug

### DIFF
--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -3,7 +3,7 @@
 .cookie-info
   Cookie in oven:
   - if @oven.cookie
-    1 cookie with #{@oven.cookie.fillings || "no fillings"}
+    1 cookie with #{@oven.cookie.fillings.length == 0 ? "no fillings" : @oven.cookie.fillings}
     - if @oven.cookie.ready?
       (Your Cookie is Ready)
       = button_to "Retrieve Cookie", empty_oven_path, class: 'button tiny'


### PR DESCRIPTION
Added ternary logic that checks if @oven.cookie.fillings is an empty string and returns "no fillings" if it's empty or the fillings if it's not. 